### PR TITLE
Add support for .plfe & .plit

### DIFF
--- a/Generated/MHW_Editor/Items/Plfe.cs
+++ b/Generated/MHW_Editor/Items/Plfe.cs
@@ -1,0 +1,79 @@
+
+using System.ComponentModel;
+using MHW_Editor.Models;
+using MHW_Template;
+using MHW_Template.Models;
+
+namespace MHW_Editor.Items {
+    public partial class Plfe {
+        public const uint StructSize = 24;
+        public const ulong InitialOffset = 10;
+        public const long EntryCountOffset = 6;
+        protected const string Fertilizer_Id_displayName = "Fertilizer Id";
+        protected const int Fertilizer_Id_sortIndex = 50;
+        [SortOrder(Fertilizer_Id_sortIndex)]
+        [DisplayName(Fertilizer_Id_displayName)]
+        public MHW_Template.Items.Fertilizer Fertilizer_Id {
+            get => (MHW_Template.Items.Fertilizer) GetData<uint>(0);
+            set {
+                SetData(0, (uint) value);
+                OnPropertyChanged(nameof(Fertilizer_Id));
+            }
+        }
+        protected const string Prize_displayName = "Prize";
+        protected const int Prize_sortIndex = 100;
+        [SortOrder(Prize_sortIndex)]
+        [DisplayName(Prize_displayName)]
+        public uint Prize {
+            get => GetData<uint>(4);
+            set {
+                SetData(4, value);
+                OnPropertyChanged(nameof(Prize));
+            }
+        }
+        protected const string Base_duration_displayName = "Base duration";
+        protected const int Base_duration_sortIndex = 150;
+        [SortOrder(Base_duration_sortIndex)]
+        [DisplayName(Base_duration_displayName)]
+        public uint Base_duration {
+            get => GetData<uint>(8);
+            set {
+                SetData(8, value);
+                OnPropertyChanged(nameof(Base_duration));
+            }
+        }
+        protected const string Unknown_int32_1_displayName = "Unknown (int32) 1";
+        protected const int Unknown_int32_1_sortIndex = 200;
+        [SortOrder(Unknown_int32_1_sortIndex)]
+        [DisplayName(Unknown_int32_1_displayName)]
+        public uint Unknown_int32_1 {
+            get => GetData<uint>(12);
+            set {
+                SetData(12, value);
+                OnPropertyChanged(nameof(Unknown_int32_1));
+            }
+        }
+        protected const string Unknown_int32_2_displayName = "Unknown (int32) 2";
+        protected const int Unknown_int32_2_sortIndex = 250;
+        [SortOrder(Unknown_int32_2_sortIndex)]
+        [DisplayName(Unknown_int32_2_displayName)]
+        public uint Unknown_int32_2 {
+            get => GetData<uint>(16);
+            set {
+                SetData(16, value);
+                OnPropertyChanged(nameof(Unknown_int32_2));
+            }
+        }
+        protected const string Unknown_int32_3_displayName = "Unknown (int32) 3";
+        protected const int Unknown_int32_3_sortIndex = 300;
+        [SortOrder(Unknown_int32_3_sortIndex)]
+        [DisplayName(Unknown_int32_3_displayName)]
+        public uint Unknown_int32_3 {
+            get => GetData<uint>(20);
+            set {
+                SetData(20, value);
+                OnPropertyChanged(nameof(Unknown_int32_3));
+            }
+        }
+    }
+}

--- a/Generated/MHW_Editor/Items/Plit.cs
+++ b/Generated/MHW_Editor/Items/Plit.cs
@@ -1,0 +1,113 @@
+
+using System.ComponentModel;
+using MHW_Editor.Models;
+using MHW_Template;
+using MHW_Template.Models;
+
+namespace MHW_Editor.Items {
+    public partial class Plit {
+        public const uint StructSize = 37;
+        public const ulong InitialOffset = 10;
+        public const long EntryCountOffset = 6;
+        protected const string Cultivation_category_displayName = "Cultivation category";
+        protected const int Cultivation_category_sortIndex = 50;
+        [SortOrder(Cultivation_category_sortIndex)]
+        [DisplayName(Cultivation_category_displayName)]
+        public MHW_Template.Items.CultivationCategory Cultivation_category {
+            get => (MHW_Template.Items.CultivationCategory) GetData<uint>(0);
+            set {
+                SetData(0, (uint) value);
+                OnPropertyChanged(nameof(Cultivation_category));
+            }
+        }
+        protected const string Unlocked_from_start_Raw_displayName = "Unlocked from start Raw";
+        protected const int Unlocked_from_start_Raw_sortIndex = 100;
+        [SortOrder(Unlocked_from_start_Raw_sortIndex)]
+        [DisplayName(Unlocked_from_start_Raw_displayName)]
+        protected byte Unlocked_from_start_Raw {
+            get => GetData<byte>(8);
+            set {
+                SetData(8, value);
+                OnPropertyChanged(nameof(Unlocked_from_start_Raw));
+            }
+        }
+        protected const string Item_displayName = "Item";
+        protected const int Item_sortIndex = 150;
+        [SortOrder(Item_sortIndex)]
+        [DisplayName(Item_displayName)]
+        [DataSource(DataSourceType.Items)]
+        public ushort Item {
+            get => GetData<ushort>(9);
+            set {
+                SetData(9, value);
+                OnPropertyChanged(nameof(Item));
+            }
+        }
+        protected const string Required_time_displayName = "Required time";
+        protected const int Required_time_sortIndex = 200;
+        [SortOrder(Required_time_sortIndex)]
+        [DisplayName(Required_time_displayName)]
+        public uint Required_time {
+            get => GetData<uint>(13);
+            set {
+                SetData(13, value);
+                OnPropertyChanged(nameof(Required_time));
+            }
+        }
+        protected const string Catalyst_time_bonus_displayName = "Catalyst time bonus";
+        protected const int Catalyst_time_bonus_sortIndex = 250;
+        [SortOrder(Catalyst_time_bonus_sortIndex)]
+        [DisplayName(Catalyst_time_bonus_displayName)]
+        public uint Catalyst_time_bonus {
+            get => GetData<uint>(17);
+            set {
+                SetData(17, value);
+                OnPropertyChanged(nameof(Catalyst_time_bonus));
+            }
+        }
+        protected const string Amount_Base__displayName = "Amount (Base)";
+        protected const int Amount_Base__sortIndex = 300;
+        [SortOrder(Amount_Base__sortIndex)]
+        [DisplayName(Amount_Base__displayName)]
+        public uint Amount_Base_ {
+            get => GetData<uint>(25);
+            set {
+                SetData(25, value);
+                OnPropertyChanged(nameof(Amount_Base_));
+            }
+        }
+        protected const string Amount_1__displayName = "Amount (+1)";
+        protected const int Amount_1__sortIndex = 350;
+        [SortOrder(Amount_1__sortIndex)]
+        [DisplayName(Amount_1__displayName)]
+        public uint Amount_1_ {
+            get => GetData<uint>(29);
+            set {
+                SetData(29, value);
+                OnPropertyChanged(nameof(Amount_1_));
+            }
+        }
+        protected const string Amount_2__displayName = "Amount (+2)";
+        protected const int Amount_2__sortIndex = 400;
+        [SortOrder(Amount_2__sortIndex)]
+        [DisplayName(Amount_2__displayName)]
+        public uint Amount_2_ {
+            get => GetData<uint>(33);
+            set {
+                SetData(33, value);
+                OnPropertyChanged(nameof(Amount_2_));
+            }
+        }
+        protected const string Unknown_int32_1_displayName = "Unknown (int32) 1";
+        protected const int Unknown_int32_1_sortIndex = 450;
+        [SortOrder(Unknown_int32_1_sortIndex)]
+        [DisplayName(Unknown_int32_1_displayName)]
+        public uint Unknown_int32_1 {
+            get => GetData<uint>(4);
+            set {
+                SetData(4, value);
+                OnPropertyChanged(nameof(Unknown_int32_1));
+            }
+        }
+    }
+}

--- a/Items/Plfe.cs
+++ b/Items/Plfe.cs
@@ -1,0 +1,11 @@
+﻿using MHW_Editor.Models;
+
+namespace MHW_Editor.Items {
+    public partial class Plfe : MhwItem {
+
+        public Plfe(byte[] bytes, ulong offset) : base(bytes, offset) {
+        }
+
+        public override string Name => "None";
+    }
+}

--- a/Items/Plit.cs
+++ b/Items/Plit.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.ComponentModel;
+using MHW_Editor.Assets;
+using MHW_Editor.Models;
+
+namespace MHW_Editor.Items {
+    public partial class Plit : MhwItem {
+
+        public Plit(byte[] bytes, ulong offset) : base(bytes, offset) {
+        }
+
+        public override string Name => "None";
+
+        [SortOrder(Item_sortIndex)]
+        [DisplayName(Item_displayName)]
+        public string Item_button => DataHelper.itemData[MainWindow.locale][Item].ToString();
+
+        [SortOrder(Unlocked_from_start_Raw_sortIndex)]
+        [DisplayName("Unlocked from start")]
+        public bool Unlocked_from_start
+        {
+            get => Convert.ToBoolean(Unlocked_from_start_Raw);
+            set => Unlocked_from_start_Raw = Convert.ToByte(value);
+        }
+    }
+}

--- a/MHW-Editor.csproj
+++ b/MHW-Editor.csproj
@@ -75,11 +75,15 @@
     <Compile Include="Controls\AutoFilteredComboBox.cs" />
     <Compile Include="Generated\MHW_Editor\Items\EqCrt.cs" />
     <Compile Include="Generated\MHW_Editor\Items\EqCus.cs" />
+    <Compile Include="Generated\MHW_Editor\Items\Plfe.cs" />
+    <Compile Include="Generated\MHW_Editor\Items\Plit.cs" />
     <Compile Include="Generated\MHW_Editor\Skills\SkillDataValueClass.cs" />
     <Compile Include="Generated\MHW_Editor\Weapons\NewLimitBreak2.cs" />
     <Compile Include="GetNewItemId.xaml.cs">
       <DependentUpon>GetNewItemId.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Items\Plfe.cs" />
+    <Compile Include="Items\Plit.cs" />
     <Compile Include="Items\EqCus.cs" />
     <Compile Include="Items\EqCrt.cs" />
     <Compile Include="Models\ColumnHolder.cs" />

--- a/MHW-Generator/Program.cs
+++ b/MHW-Generator/Program.cs
@@ -42,6 +42,43 @@ namespace MHW_Generator {
             GenASkill();
             GenEqCrt();
             GenEqCus();
+            GenPlfe();
+            GenPlit();
+        }
+
+        private static void GenPlfe() {
+            GenerateItemProps("MHW_Editor.Items", "Plfe", new MhwStructData {
+                size = 24,
+                offsetInitial = 10,
+                entryCountOffset = 6,
+                entries = new List<MhwStructData.Entry> {
+                    new MhwStructData.Entry("Fertilizer Id", 0, typeof(uint), typeof(Fertilizer)),
+                    new MhwStructData.Entry("Prize", 4, typeof(uint)),
+                    new MhwStructData.Entry("Base duration", 8, typeof(uint)),
+                    new MhwStructData.Entry("Unknown (int32) 1", 12, typeof(uint)),
+                    new MhwStructData.Entry("Unknown (int32) 2", 16, typeof(uint)),
+                    new MhwStructData.Entry("Unknown (int32) 3", 20, typeof(uint))
+                }
+            });
+        }
+
+        private static void GenPlit() {
+            GenerateItemProps("MHW_Editor.Items", "Plit", new MhwStructData {
+                size = 37,
+                offsetInitial = 10,
+                entryCountOffset = 6,
+                entries = new List<MhwStructData.Entry> {
+                    new MhwStructData.Entry("Cultivation category", 0, typeof(uint), typeof(CultivationCategory)),
+                    new MhwStructData.Entry("Unlocked from start Raw", 8, typeof(byte), accessLevel: "protected"),
+                    new MhwStructData.Entry("Item", 9, typeof(ushort), dataSourceType: DataSourceType.Items),
+                    new MhwStructData.Entry("Required time", 13, typeof(uint)),
+                    new MhwStructData.Entry("Catalyst time bonus", 17, typeof(uint)),
+                    new MhwStructData.Entry("Amount (Base)", 25, typeof(uint)),
+                    new MhwStructData.Entry("Amount (+1)", 29, typeof(uint)),
+                    new MhwStructData.Entry("Amount (+2)", 33, typeof(uint)),
+                    new MhwStructData.Entry("Unknown (int32) 1", 4, typeof(uint))
+                }
+            });
         }
 
         private static void GenEqCus() {

--- a/MHW-Template/Items/CultivationCategory.cs
+++ b/MHW-Template/Items/CultivationCategory.cs
@@ -1,0 +1,7 @@
+﻿namespace MHW_Template.Items {
+    public enum CultivationCategory {
+        Plants = 1,
+        Bugs = 2,
+        Mushrooms = 3
+    }
+}

--- a/MHW-Template/Items/Fertilizer.cs
+++ b/MHW-Template/Items/Fertilizer.cs
@@ -1,0 +1,13 @@
+﻿namespace MHW_Template.Items {
+    public enum Fertilizer {
+        Fertilizer = 1,
+        Mushroom_Subtrate = 2,
+        Summoner_Jelly,
+        Catalyst,
+        Mega_Fertilizer,
+        Choice_Mushroom_Subtrate,
+        Thick_Summoner_Jelly,
+        Ancient_Catalyst,
+        Soft_Soil,
+    }
+}

--- a/MHW-Template/MHW-Template.csproj
+++ b/MHW-Template/MHW-Template.csproj
@@ -47,6 +47,8 @@
     <Compile Include="Armors\Variant.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Global.cs" />
+    <Compile Include="Items\CultivationCategory.cs" />
+    <Compile Include="Items\Fertilizer.cs" />
     <Compile Include="Items\ItemFlags.cs" />
     <Compile Include="Items\ItemSubType.cs" />
     <Compile Include="Items\ItemType.cs" />

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -45,6 +45,8 @@ namespace MHW_Editor {
             "*.kire",
             "*.new_lb",
             "*.new_lbr",
+            "*.plfe",
+            "*.plit",
             "*.sgpa",
             "*.shl_tbl",
             "*.skl_dat",
@@ -82,7 +84,8 @@ namespace MHW_Editor {
                                            nameof(Armor.Skill_1_button),
                                            nameof(Armor.Skill_2_button),
                                            nameof(Armor.Skill_3_button),
-                                           nameof(Melee.Skill_button));
+                                           nameof(Melee.Skill_button),
+                                           nameof(Plit.Item_button));
                 }
             }
         }
@@ -164,7 +167,9 @@ namespace MHW_Editor {
                                                  typeof(SkillPointData),
                                                  typeof(ASkill),
                                                  typeof(EqCrt),
-                                                 typeof(EqCus));
+                                                 typeof(EqCus),
+                                                 typeof(Plfe),
+                                                 typeof(Plit));
                     break;
                 case nameof(SkillDat.Id):
                     e.Cancel = targetFileType.Is(typeof(SkillDat));
@@ -181,6 +186,7 @@ namespace MHW_Editor {
                 case nameof(Armor.Skill_2):
                 case nameof(Armor.Skill_3):
                 case nameof(Melee.Skill):
+                case nameof(Plit.Item):
                     e.Cancel = true; // Cancel for itemId/skillId columns as we will use a text version with onClick opening a selector.
                     break;
                 default:
@@ -871,6 +877,14 @@ namespace MHW_Editor {
 
             if (fileName.EndsWith(".eq_cus")) {
                 return typeof(EqCus);
+            }
+
+            if (fileName.EndsWith(".plfe")) {
+                return typeof(Plfe);
+            }
+
+            if (fileName.EndsWith(".plit")) {
+                return typeof(Plit);
             }
 
             throw new Exception($"No type found for: {fileName}");


### PR DESCRIPTION
Adds support for .plfe (fertilizer costs and duration) and .plit (cultivation items).

.plfe:
![plfe](https://user-images.githubusercontent.com/5725237/73795510-12496100-47ab-11ea-9067-45f05456e88c.png)
.plit:
![plit](https://user-images.githubusercontent.com/5725237/73795511-12e1f780-47ab-11ea-84c2-882beaaf108c.png)
