### PR TITLE
Add Bonus Reward Struct (.brem)

### DIFF
--- a/010 Templates/brem.bt
+++ b/010 Templates/brem.bt
@@ -1,0 +1,39 @@
+//------------------------------------------------
+//--- 010 Editor v10.0 Binary Template
+//   Authors: Many. See MHW Editor Cretits.
+// File Mask: *.brem
+//  Category: MHW-Editor
+//------------------------------------------------
+
+// Header
+typedef struct {
+    uint Magic_1<name="Magic 1 (uint)">;
+    uint Magic_2<name="Magic 2 (uint)">;
+    ushort Magic_3<name="Magic 3 (ushort)">;
+    uint Monster_Ingame_Id<name="Monster Ingame Id (uint)">;
+    ubyte Part_Id_<name="Part Id (?) (ubyte)">;
+    uint Magic_4<name="Magic 4 (uint)">;
+} Header;
+
+Header Header_<name="Header">;
+
+// Items
+typedef struct {
+    uint Item_Id<name="Item Id (uint)">;
+} Items;
+
+Items Items_[8]<optimize=false, name="Items">;
+
+// Counts
+typedef struct {
+    ubyte Item_Count<name="Item Count (ubyte)">;
+} Counts;
+
+Counts Counts_[8]<optimize=false, name="Counts">;
+
+// Weights
+typedef struct {
+    ubyte Item_Weight<name="Item Weight (ubyte)">;
+} Weights;
+
+Weights Weights_[8]<optimize=false, name="Weights">;

--- a/Controls/MhwDataGrid.xaml.cs
+++ b/Controls/MhwDataGrid.xaml.cs
@@ -667,6 +667,19 @@ namespace MHW_Editor.Controls {
                     var x = (QuestReward.QuestRewardCustomView) (object) item;
                     x.Item_Weight_percent = x.Item_Weight > 0f ? (float) x.Item_Weight / total : 0f;
                 }
+            } else if (typeof(T).Is(typeof(BonusReward.BonusRewardCustomView))) {
+                //Since the BonusReward class is partially generated,
+                //it's annoying to make the QuestRewardCustomView work with BonusRewards,
+                //and only because they are only 8 instead of 16 table entries
+                //and have a different header...
+                var total = items.Select(item => (BonusReward.BonusRewardCustomView)(object)item)
+                                 .Aggregate(0u, (current, item) => current + item.Item_Weight);
+
+                foreach (var item in items)
+                {
+                    var x = (BonusReward.BonusRewardCustomView)(object)item;
+                    x.Item_Weight_percent = x.Item_Weight > 0f ? (float)x.Item_Weight / total : 0f;
+                }
             }
         }
     }

--- a/Controls/MhwDataGrid.xaml.cs
+++ b/Controls/MhwDataGrid.xaml.cs
@@ -102,7 +102,8 @@ namespace MHW_Editor.Controls {
                 // This will set the merged check on all those filters so all we have to do layer is update the filter text, then refresh.
                 ((ListCollectionView) ItemsSource).Filter = groupFilter.MergedFilters;
 
-                if (mainWindow.targetFileType.Is(typeof(DecoGradeLottery),
+                if (mainWindow.targetFileType.Is(typeof(BonusReward),
+                                                 typeof(DecoGradeLottery),
                                                  typeof(DecoLottery),
                                                  typeof(ItemLottery),
                                                  typeof(KulveGradeLottery),

--- a/Generated/MHW_Editor/Structs/Items/BonusReward.cs
+++ b/Generated/MHW_Editor/Structs/Items/BonusReward.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using MHW_Editor.Assets;
+using MHW_Editor.Controls.Models;
+using MHW_Editor.Models;
+using MHW_Editor.Windows;
+using MHW_Template;
+using MHW_Template.Models;
+
+namespace MHW_Editor.Structs.Items {
+    public partial class BonusReward {
+        public override string EncryptionKey => null;
+
+        public partial class Header : MhwStructItem, IWriteData {
+            public const ulong FixedSizeCount = 1;
+            public const string GridName = "Header";
+
+            protected uint Magic_1_raw;
+            public const string Magic_1_displayName = "Magic 1";
+            public const int Magic_1_sortIndex = 50;
+            [SortOrder(Magic_1_sortIndex)]
+            [DisplayName(Magic_1_displayName)]
+            [IsReadOnly]
+            public virtual uint Magic_1 {
+                get => Magic_1_raw;
+                set {
+                    if (Magic_1_raw == value) return;
+                    Magic_1_raw = value;
+                    ChangedItems.Add(nameof(Magic_1));
+                    OnPropertyChanged(nameof(Magic_1));
+                }
+            }
+
+            protected uint Magic_2_raw;
+            public const string Magic_2_displayName = "Magic 2";
+            public const int Magic_2_sortIndex = 100;
+            [SortOrder(Magic_2_sortIndex)]
+            [DisplayName(Magic_2_displayName)]
+            [IsReadOnly]
+            public virtual uint Magic_2 {
+                get => Magic_2_raw;
+                set {
+                    if (Magic_2_raw == value) return;
+                    Magic_2_raw = value;
+                    ChangedItems.Add(nameof(Magic_2));
+                    OnPropertyChanged(nameof(Magic_2));
+                }
+            }
+
+            protected ushort Magic_3_raw;
+            public const string Magic_3_displayName = "Magic 3";
+            public const int Magic_3_sortIndex = 150;
+            [SortOrder(Magic_3_sortIndex)]
+            [DisplayName(Magic_3_displayName)]
+            [IsReadOnly]
+            public virtual ushort Magic_3 {
+                get => Magic_3_raw;
+                set {
+                    if (Magic_3_raw == value) return;
+                    Magic_3_raw = value;
+                    ChangedItems.Add(nameof(Magic_3));
+                    OnPropertyChanged(nameof(Magic_3));
+                }
+            }
+
+            protected uint Monster_Ingame_Id_raw;
+            public const string Monster_Ingame_Id_displayName = "Monster Ingame Id";
+            public const int Monster_Ingame_Id_sortIndex = 200;
+            [SortOrder(Monster_Ingame_Id_sortIndex)]
+            [DisplayName(Monster_Ingame_Id_displayName)]
+            [IsReadOnly]
+            public virtual uint Monster_Ingame_Id {
+                get => Monster_Ingame_Id_raw;
+                set {
+                    if (Monster_Ingame_Id_raw == value) return;
+                    Monster_Ingame_Id_raw = value;
+                    ChangedItems.Add(nameof(Monster_Ingame_Id));
+                    OnPropertyChanged(nameof(Monster_Ingame_Id));
+                }
+            }
+
+            protected byte Part_Id__raw;
+            public const string Part_Id__displayName = "Part Id (?)";
+            public const int Part_Id__sortIndex = 250;
+            [SortOrder(Part_Id__sortIndex)]
+            [DisplayName(Part_Id__displayName)]
+            [IsReadOnly]
+            public virtual byte Part_Id_ {
+                get => Part_Id__raw;
+                set {
+                    if (Part_Id__raw == value) return;
+                    Part_Id__raw = value;
+                    ChangedItems.Add(nameof(Part_Id_));
+                    OnPropertyChanged(nameof(Part_Id_));
+                }
+            }
+
+            protected uint Magic_4_raw;
+            public const string Magic_4_displayName = "Magic 4";
+            public const int Magic_4_sortIndex = 300;
+            [SortOrder(Magic_4_sortIndex)]
+            [DisplayName(Magic_4_displayName)]
+            [IsReadOnly]
+            public virtual uint Magic_4 {
+                get => Magic_4_raw;
+                set {
+                    if (Magic_4_raw == value) return;
+                    Magic_4_raw = value;
+                    ChangedItems.Add(nameof(Magic_4));
+                    OnPropertyChanged(nameof(Magic_4));
+                }
+            }
+
+            public const int lastSortIndex = 350;
+
+            public static ObservableMhwStructCollection<Header> LoadData(BinaryReader reader) {
+                var list = new ObservableMhwStructCollection<Header>();
+                const ulong count = 1UL;
+                for (ulong i = 0; i < count; i++) {
+                    list.Add(LoadData(reader, i));
+                }
+                return list;
+            }
+
+            public static Header LoadData(BinaryReader reader, ulong i) {
+                var data = new Header();
+                data.Index = i;
+                data.Magic_1_raw = reader.ReadUInt32();
+                data.Magic_2_raw = reader.ReadUInt32();
+                data.Magic_3_raw = reader.ReadUInt16();
+                data.Monster_Ingame_Id_raw = reader.ReadUInt32();
+                data.Part_Id__raw = reader.ReadByte();
+                data.Magic_4_raw = reader.ReadUInt32();
+                return data;
+            }
+
+            public void WriteData(BinaryWriter writer) {
+                writer.Write(Magic_1_raw);
+                writer.Write(Magic_2_raw);
+                writer.Write(Magic_3_raw);
+                writer.Write(Monster_Ingame_Id_raw);
+                writer.Write(Part_Id__raw);
+                writer.Write(Magic_4_raw);
+            }
+        }
+
+        public partial class Items : MhwStructItem, IWriteData {
+            public const ulong FixedSizeCount = 8;
+            public const string GridName = "Items";
+
+            protected uint Item_Id_raw;
+            public const string Item_Id_displayName = "Item Id";
+            public const int Item_Id_sortIndex = 50;
+            [SortOrder(Item_Id_sortIndex)]
+            [DisplayName(Item_Id_displayName)]
+            [DataSource(DataSourceType.Items)]
+            public virtual uint Item_Id {
+                get => Item_Id_raw;
+                set {
+                    if (Item_Id_raw == value) return;
+                    Item_Id_raw = value;
+                    ChangedItems.Add(nameof(Item_Id));
+                    OnPropertyChanged(nameof(Item_Id));
+                    OnPropertyChanged(nameof(Item_Id_button));
+                }
+            }
+
+            [SortOrder(Item_Id_sortIndex)]
+            [DisplayName(Item_Id_displayName)]
+            [CustomSorter(typeof(ButtonSorter))]
+            public string Item_Id_button => DataHelper.itemNames[MainWindow.locale].TryGet(Item_Id).ToStringWithId(Item_Id);
+
+            public const int lastSortIndex = 100;
+
+            public static ObservableMhwStructCollection<Items> LoadData(BinaryReader reader) {
+                var list = new ObservableMhwStructCollection<Items>();
+                const ulong count = 8UL;
+                for (ulong i = 0; i < count; i++) {
+                    list.Add(LoadData(reader, i));
+                }
+                return list;
+            }
+
+            public static Items LoadData(BinaryReader reader, ulong i) {
+                var data = new Items();
+                data.Index = i;
+                data.Item_Id_raw = reader.ReadUInt32();
+                return data;
+            }
+
+            public void WriteData(BinaryWriter writer) {
+                writer.Write(Item_Id_raw);
+            }
+        }
+
+        public partial class Counts : MhwStructItem, IWriteData {
+            public const ulong FixedSizeCount = 8;
+            public const string GridName = "Counts";
+
+            protected byte Item_Count_raw;
+            public const string Item_Count_displayName = "Item Count";
+            public const int Item_Count_sortIndex = 50;
+            [SortOrder(Item_Count_sortIndex)]
+            [DisplayName(Item_Count_displayName)]
+            public virtual byte Item_Count {
+                get => Item_Count_raw;
+                set {
+                    if (Item_Count_raw == value) return;
+                    Item_Count_raw = value;
+                    ChangedItems.Add(nameof(Item_Count));
+                    OnPropertyChanged(nameof(Item_Count));
+                }
+            }
+
+            public const int lastSortIndex = 100;
+
+            public static ObservableMhwStructCollection<Counts> LoadData(BinaryReader reader) {
+                var list = new ObservableMhwStructCollection<Counts>();
+                const ulong count = 8UL;
+                for (ulong i = 0; i < count; i++) {
+                    list.Add(LoadData(reader, i));
+                }
+                return list;
+            }
+
+            public static Counts LoadData(BinaryReader reader, ulong i) {
+                var data = new Counts();
+                data.Index = i;
+                data.Item_Count_raw = reader.ReadByte();
+                return data;
+            }
+
+            public void WriteData(BinaryWriter writer) {
+                writer.Write(Item_Count_raw);
+            }
+        }
+
+        public partial class Weights : MhwStructItem, IWriteData {
+            public const ulong FixedSizeCount = 8;
+            public const string GridName = "Weights";
+
+            protected byte Item_Weight_raw;
+            public const string Item_Weight_displayName = "Item Weight";
+            public const int Item_Weight_sortIndex = 50;
+            [SortOrder(Item_Weight_sortIndex)]
+            [DisplayName(Item_Weight_displayName)]
+            public virtual byte Item_Weight {
+                get => Item_Weight_raw;
+                set {
+                    if (Item_Weight_raw == value) return;
+                    Item_Weight_raw = value;
+                    ChangedItems.Add(nameof(Item_Weight));
+                    OnPropertyChanged(nameof(Item_Weight));
+                }
+            }
+
+            public const int lastSortIndex = 100;
+
+            public static ObservableMhwStructCollection<Weights> LoadData(BinaryReader reader) {
+                var list = new ObservableMhwStructCollection<Weights>();
+                const ulong count = 8UL;
+                for (ulong i = 0; i < count; i++) {
+                    list.Add(LoadData(reader, i));
+                }
+                return list;
+            }
+
+            public static Weights LoadData(BinaryReader reader, ulong i) {
+                var data = new Weights();
+                data.Index = i;
+                data.Item_Weight_raw = reader.ReadByte();
+                return data;
+            }
+
+            public void WriteData(BinaryWriter writer) {
+                writer.Write(Item_Weight_raw);
+            }
+        }
+
+        public override void LoadFile(string targetFile) {
+            using var reader = new BinaryReader(OpenFile(targetFile, EncryptionKey), Encoding.UTF8);
+            data = new LinkedList<MhwStructDataContainer>();
+            var Header_ = new MhwStructDataContainer<Header>(Header.LoadData(reader), typeof(Header));
+            data.AddLast(Header_);
+            var Items_ = new MhwStructDataContainer<Items>(Items.LoadData(reader), typeof(Items));
+            data.AddLast(Items_);
+            var Counts_ = new MhwStructDataContainer<Counts>(Counts.LoadData(reader), typeof(Counts));
+            data.AddLast(Counts_);
+            var Weights_ = new MhwStructDataContainer<Weights>(Weights.LoadData(reader), typeof(Weights));
+            data.AddLast(Weights_);
+        }
+    }
+}

--- a/MHW-Generator/Items/BonusReward.cs
+++ b/MHW-Generator/Items/BonusReward.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using MHW_Generator.Models;
+using MHW_Template.Models;
+using MHW_Template.Struct_Generation;
+
+namespace MHW_Generator.Items {
+    public class BonusReward : SingleStructBase, IMultiStruct {
+        public MultiStruct Generate() { // .brem
+            var structs = new List<MhwMultiStructData.StructData> {
+                new MhwMultiStructData.StructData("Header", new List<MhwMultiStructData.Entry> {
+                    new MhwMultiStructData.Entry("Magic 1", typeof(uint), true),
+                    new MhwMultiStructData.Entry("Magic 2", typeof(uint), true),
+                    new MhwMultiStructData.Entry("Magic 3", typeof(ushort), true),
+                    new MhwMultiStructData.Entry("Monster Ingame Id", typeof(uint), true),
+                    new MhwMultiStructData.Entry("Part Id (?)", typeof(byte), true),
+                    new MhwMultiStructData.Entry("Magic 4", typeof(uint), true)
+                }, 1),
+
+                new MhwMultiStructData.StructData("Items", new List<MhwMultiStructData.Entry> {
+                    new MhwMultiStructData.Entry("Item Id", typeof(uint), dataSourceType: DataSourceType.Items)
+                }, 8),
+
+                new MhwMultiStructData.StructData("Counts", new List<MhwMultiStructData.Entry> {
+                    new MhwMultiStructData.Entry("Item Count", typeof(byte))
+                }, 8),
+
+                new MhwMultiStructData.StructData("Weights", new List<MhwMultiStructData.Entry> {
+                    new MhwMultiStructData.Entry("Item Weight", typeof(byte))
+                }, 8)
+            };
+
+            return new MultiStruct("Items", "BonusReward", new MhwMultiStructData(structs, "brem"));
+        }
+    }
+}

--- a/MHW-Template/Global.cs
+++ b/MHW-Template/Global.cs
@@ -45,6 +45,7 @@ namespace MHW_Template {
             "*.ask",
             "*.asp",
             "*.bbtbl",
+            "*.brem",
             "*.ch_dat",
             "*.cat_skill",
             "*.col",

--- a/Structs/Items/BonusReward.cs
+++ b/Structs/Items/BonusReward.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows.Controls;
+using MHW_Editor.Assets;
+using MHW_Editor.Controls.Models;
+using MHW_Editor.Models;
+using MHW_Editor.Windows;
+using MHW_Template;
+using MHW_Template.Models;
+
+namespace MHW_Editor.Structs.Items {
+    public partial class BonusReward : MhwMultiStructFile<BonusReward> {
+        public override void SetupViews(Grid grid, MainWindow main) {
+            var customViews = new List<BonusRewardCustomView>((int) Items.FixedSizeCount);
+            for (var i = 0; i < (int) Items.FixedSizeCount; i++) {
+                customViews.Add(new BonusRewardCustomView());
+            }
+
+            foreach (var entry in data) {
+                if (!entry.type.Is(typeof(Items), typeof(Counts), typeof(Weights))) continue;
+
+                for (var i = 0; i < (int) Items.FixedSizeCount; i++) {
+                    var customView = customViews[i];
+                    var entryItem  = ((dynamic) entry).list[i];
+
+                    if (entry.type.Is(typeof(Items))) {
+                        customView.itemIdEntry = (Items) entryItem;
+                    } else if (entry.type.Is(typeof(Counts))) {
+                        customView.itemCountEntry = (Counts) entryItem;
+                    } else if (entry.type.Is(typeof(Weights))) {
+                        customView.itemWeightEntry = (Weights) entryItem;
+                    }
+                }
+            }
+
+            grid.AddControl(new Label {Content = "Bonus Rewards", FontSize = MainWindow.FONT_SIZE});
+            main.AddDataGrid(customViews);
+        }
+
+        /// <summary>
+        /// Technically Identical to QuestRewardCustomView, but due to different 
+        /// Items, Counts and Weights classes that were generated, this needs to be separate, 
+        /// or the "original" one would have to be generic for example.
+        /// </summary>
+        public sealed class BonusRewardCustomView : MhwStructItem {
+            internal Items   itemIdEntry;
+            internal Counts  itemCountEntry;
+            internal Weights itemWeightEntry;
+
+            private const int Item_Id_sortIndex = 50;
+            [SortOrder(Item_Id_sortIndex)]
+            [DisplayName(Items.Item_Id_displayName)]
+            [DataSource(DataSourceType.Items)]
+            public uint Item_Id {
+                get => itemIdEntry.Item_Id;
+                set {
+                    if (itemIdEntry.Item_Id == value) return;
+                    itemIdEntry.Item_Id = value;
+                    OnPropertyChanged(nameof(Item_Id));
+                    OnPropertyChanged(nameof(Item_Id_button));
+                }
+            }
+
+            [SortOrder(Item_Id_sortIndex)]
+            [DisplayName(Items.Item_Id_displayName)]
+            [CustomSorter(typeof(ButtonSorter))]
+            public string Item_Id_button => DataHelper.itemNames[MainWindow.locale].TryGet(Item_Id).ToStringWithId(Item_Id);
+
+            [SortOrder(100)]
+            [DisplayName(Counts.Item_Count_displayName)]
+            public byte Item_Count {
+                get => itemCountEntry.Item_Count;
+                set {
+                    if (itemCountEntry.Item_Count == value) return;
+                    itemCountEntry.Item_Count = value;
+                    OnPropertyChanged(nameof(Item_Count));
+                }
+            }
+
+            [SortOrder(150)]
+            [DisplayName(Weights.Item_Weight_displayName)]
+            public byte Item_Weight {
+                get => itemWeightEntry.Item_Weight;
+                set {
+                    if (itemWeightEntry.Item_Weight == value) return;
+                    itemWeightEntry.Item_Weight = value;
+                    OnPropertyChanged(nameof(Item_Weight));
+                }
+            }
+
+            private float itemWeightPercent;
+            [SortOrder(200)]
+            [DisplayName(Weights.Item_Weight_displayName + "%")]
+            public float Item_Weight_percent {
+                get => itemWeightPercent;
+                set {
+                    itemWeightPercent = value.Clamp(0f, 100f);
+                    OnPropertyChanged(nameof(Item_Weight_percent));
+                }
+            }
+        }
+    }
+}

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -415,7 +415,8 @@ namespace MHW_Editor.Windows {
 
             btn_sort_jewel_order_by_name.Visibility = targetFileType.Is(typeof(Item)).VisibleIfTrue();
 
-            cb_show_id_before_name.Visibility = (targetFileType.Is(typeof(DecoGradeLottery),
+            cb_show_id_before_name.Visibility = (targetFileType.Is(typeof(BonusReward),
+                                                                   typeof(DecoGradeLottery),
                                                                    typeof(DecoLottery),
                                                                    typeof(KulveGradeLottery),
                                                                    typeof(MusicSkill),
@@ -691,6 +692,7 @@ namespace MHW_Editor.Windows {
             if (fileName.EndsWith(".ask")) return typeof(ASkill);
             if (fileName.EndsWith(".asp")) return typeof(PlMantleParam);
             if (fileName.EndsWith(".bbtbl")) return typeof(BottleTable);
+            if (fileName.EndsWith(".brem")) return typeof(BonusReward);
             if (fileName.EndsWith(".cat_skill")) return typeof(CatSkill);
             if (fileName.EndsWith(".ch_dat")) return typeof(PendantData);
             if (fileName.EndsWith(".col")) return typeof(Collision);


### PR DESCRIPTION
Trivial Implementation, based off of QuestReward, thus a lot of duplicate code. Optimization possible by making them use the same UI/View code, but that requires changing generated code for both, which I'm not sure is in the spirit of the code generator.

Bonus rewards work basically like a QuestReward .rem file, just only with 8 instead of 16 entries. Also, they reference the monster, not a quest ID, and (probably?) a monster part, both in their header and their filename (the values from filename and header match). Since the body part is only one byte, the header has a weird offset of 13 bytes (unlike the 12 bytes of .rem), so maybe that's why it hasn't been added yet?
The header also references the ingame ID of the corresponding monster (which is not equal to the EM ID, since that seems to be species or so, with subspecies getting a sub index there).
I was unable to identify any more magic numbers for now, though the last 4 bytes change between different brem files.