### PR TITLE
Fix multi cell editing

### DIFF
--- a/Controls/MhwDataGrid.xaml
+++ b/Controls/MhwDataGrid.xaml
@@ -14,9 +14,13 @@
           EnableRowVirtualization="True"
           GotFocus="On_GotFocus"
           HorizontalScrollBarVisibility="Disabled"
-          SelectionUnit="CellOrRowHeader"
+          SelectionUnit="Cell"
+          SelectionMode="Extended"
           Sorting="On_Sorting"
           VerticalScrollBarVisibility="Disabled"
+          KeyDown="DataGrid_KeyDown"
+          SelectionChanged="DataGrid_SelectionChanged"
+          PreviewKeyDown="DataGrid_PreviewKeyDown"
           mc:Ignorable="d">
     <DataGrid.Resources>
         <Style TargetType="{x:Type DataGridCell}">

--- a/Util/UpdateCheck.cs
+++ b/Util/UpdateCheck.cs
@@ -15,6 +15,7 @@ using Newtonsoft.Json;
 namespace MHW_Editor.Util {
     public static class UpdateCheck {
         private const string NEXUS_LINK = "https://www.nexusmods.com/monsterhunterworld/mods/2068";
+        public static bool SingleClick_Mode = true;
 
         [CanBeNull] public static NotifyIcon notifyIcon;
 

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -97,7 +97,7 @@ namespace MHW_Editor.Windows {
             }
         }
 
-        public bool SingleClickToEditMode { get; set; } = true;
+        public bool SingleClickToEditMode { get { return UpdateCheck.SingleClick_Mode; } set { UpdateCheck.SingleClick_Mode = value; } }
 
         public MainWindow() {
             var args = Environment.GetCommandLineArgs();


### PR DESCRIPTION
Fix multi cell editing.

Works correctly when deactivating Single Click Mode.

The goal is to be able to select several boxes and edit them all at the same time with copy and paste